### PR TITLE
Add the url for the repository field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "./build/index.js",
   "repository": {
     "type": "git",
-    "url": ""
+    "url": "sophstad/react-heatmap-graph"
   },
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
I found your package on npm, but couldn't find the actual source without a bit of searching.
This way the nom page for your package will include a link back to the repository.